### PR TITLE
Fix ordinal metric

### DIFF
--- a/krippendorff/krippendorff.py
+++ b/krippendorff/krippendorff.py
@@ -17,7 +17,7 @@ def _nominal_metric(v1, v2, **_kwargs):
 
 def _ordinal_metric(_v1, _v2, i1, i2, n_v):
     """Metric for ordinal data."""
-    return np.sum(n_v[i1:(i2 + 1)]) - (n_v[i1] + n_v[i2]) / 2
+    return (np.sum(n_v[i1:(i2 + 1)]) - (n_v[i1] + n_v[i2]) / 2) ** 2
 
 
 def _interval_metric(v1, v2, **_kwargs):


### PR DESCRIPTION
Hello. Thanks for your work. As you may see on Wikipedia ordinal metric has calculated as the square of this formula. [Wiki](https://en.wikipedia.org/wiki/Krippendorff%27s_alpha#Difference_functions)