### PR TITLE
Fixes for Value domain assert fails when using np.nan values. np.isnan fails on reliability_data strings.

### DIFF
--- a/krippendorff/krippendorff.py
+++ b/krippendorff/krippendorff.py
@@ -261,7 +261,7 @@ def alpha(reliability_data: Optional[Iterable[Any]] = None, value_counts: Option
             # np.asarray will coerce np.nan values to 'nan'
             found_value_domain = np.unique(reliability_data[reliability_data != 'nan'])
         else:
-            raise ValueError("Don't know how to construct value domain for dtype kind {kind}.")
+            raise ValueError(f"Don't know how to construct value domain for dtype kind {kind}.")
 
         if value_domain is None:
             # Check if Unicode or byte string


### PR DESCRIPTION
Hi @bryant1410,

This PR has my proposed fixes for #12. I made a new PR so I could provide you a clean, squashed commit on current main.

Here are my proposed fixes for handling both numeric and string reliability_data, in particular when the value_domain is not provided and has to be inferred from the reliability_data. As part of validating value_domain, I added two ValueError exceptions for situations where the code can't determine a value_domain.

Note that we want to construct the found_value_domain regardless of whether it was provided or not, so we can either use it, or check the found_value_domain against the user provided value_domain as a sanity check.

When constructing the found_value_domain, I simply filter out np.nan or 'nan' depending on the dtype.kind. np.nan is not part of the value domain and is always allowed. Also, as we determined before, np.isin uses equality to test, and np.nan != np.nan. So removing np.nan or 'nan' simplifies the assertion that checks the found_value_domain against the user provided value_domain.

I decided it was much cleaner and easier to follow the purpose of the code by examining dtype.kind rather than to try and catch TypeError exceptions which would be much more mysterious looking.

The two doctests I added previously now pass. The second doctest had to be changed to level_of_measurement='nominal' since it is not possible to infer an ordered value_domain from strings.

Please let me know of any questions or feedback.